### PR TITLE
Handle missing card fields in search

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -159,8 +159,8 @@ class MemoryApp extends EventEmitter {
     const q = query.toLowerCase();
     const results = [];
     for (const card of this.cards.values()) {
-      const title = card.title.toLowerCase();
-      const content = card.content.toLowerCase();
+      const title = (card.title || '').toLowerCase();
+      const content = (card.content || '').toLowerCase();
       const description = (card.description || '').toLowerCase();
       if (title.includes(q) || content.includes(q) || description.includes(q)) {
         results.push(card);

--- a/test.js
+++ b/test.js
@@ -53,6 +53,14 @@ const MemoryApp = require('./src/app');
   assert.ok(!app.decks.has('general'), 'Deck should be removed from app');
   assert.ok(!app.cards.get(second.id).decks.has('general'), 'Card should no longer list removed deck');
 
+  // Searching cards missing title or content
+  const searchApp = new MemoryApp();
+  searchApp.setAIEnabled(false);
+  const titleOnly = await searchApp.createCard({ title: 'Title Only' });
+  const contentOnly = await searchApp.createCard({ content: 'Content Only' });
+  assert.strictEqual(searchApp.searchByText('title')[0].id, titleOnly.id, 'Search should find card lacking content');
+  assert.strictEqual(searchApp.searchByText('content')[0].id, contentOnly.id, 'Search should find card lacking title');
+
   // Generic content handling with source persistence
   const mediaApp = new MemoryApp();
   const mediaCard = await mediaApp.createCard({


### PR DESCRIPTION
## Summary
- guard search by text against missing card title or content
- add tests for searching cards missing a title or content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4f04c6288322aa7d1bb60598d9fd