### PR TITLE
Prevent duplicate card IDs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,9 @@ class MemoryApp extends EventEmitter {
         this.nextId = num + 1;
       }
     }
+    if (this.cards.has(data.id)) {
+      throw new Error('Card ID already exists');
+    }
     const card = new Card(data);
     this.cards.set(card.id, card);
     this.emit('cardCreated', card);

--- a/test.js
+++ b/test.js
@@ -20,6 +20,11 @@ const { fetchSuggestion } = require('./src/suggestions');
   assert.strictEqual(app.cards.size, 1, 'Card count should be 1');
   assert.ok(app.decks.get('general').cards.has(card.id), 'Deck should contain card');
   assert.strictEqual(app.searchByTag('intro')[0].id, card.id, 'Search should return the card');
+  await assert.rejects(
+    app.createCard({ id: card.id, title: 'Dup', content: 'Dup content' }),
+    /already exists/
+  );
+  assert.strictEqual(app.cards.size, 1, 'Duplicate card should not be added');
 
   const second = await app.createCard({
     title: 'Second note',


### PR DESCRIPTION
## Summary
- avoid creating cards with duplicate IDs by checking existing map and throwing an error
- add tests ensuring duplicate card creation is rejected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e650b33448322be70de46da2af2d4