### PR TITLE
Refactor suggestion retrieval for parallel fetching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -169,14 +169,15 @@ class MemoryApp extends EventEmitter {
     if (!card) {
       return [];
     }
-    const results = [];
+    const pending = [];
     for (const tag of card.tags) {
-      if (results.length >= limit) {
+      if (pending.length >= limit) {
         break;
       }
-      results.push(await fetchSuggestion(tag, card.type));
+      pending.push(fetchSuggestion(tag, card.type));
     }
-    return results;
+    const results = await Promise.all(pending);
+    return results.filter(r => r);
   }
 
   async getThemeSuggestions(limit = 3) {
@@ -192,14 +193,15 @@ class MemoryApp extends EventEmitter {
     const sorted = Array.from(counts.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([tag]) => tag);
-    const results = [];
+    const pending = [];
     for (const tag of sorted) {
-      if (results.length >= limit) {
+      if (pending.length >= limit) {
         break;
       }
-      results.push(await fetchSuggestion(tag));
+      pending.push(fetchSuggestion(tag));
     }
-    return results;
+    const results = await Promise.all(pending);
+    return results.filter(r => r);
   }
 
   async getWebSuggestions(limit = 3) {

--- a/test.js
+++ b/test.js
@@ -240,6 +240,26 @@ const { fetchSuggestion } = require('./src/suggestions');
   const thirdLink = reloaded.createLink(c1.id, c3.id, 'relates');
   assert.strictEqual(thirdLink.id, '3', 'Link ID should continue after reload');
 
+  // Suggestion filtering of null results
+  delete require.cache[require.resolve('./src/app')];
+  delete require.cache[require.resolve('./src/suggestions')];
+  require.cache[require.resolve('./src/suggestions')] = {
+    exports: {
+      fetchSuggestion: async tag => tag === 'nulltag'
+        ? null
+        : { tag, title: tag, description: '', url: '', source: 'test' }
+    }
+  };
+  const FilterApp = require('./src/app');
+  const filterApp = new FilterApp();
+  const filterCard = await filterApp.createCard({ title: 'Filter', content: '', tags: ['nulltag', 'good'] });
+  const cardFiltered = await filterApp.getCardSuggestions(filterCard.id, 5);
+  assert.strictEqual(cardFiltered.length, 1, 'Card suggestions should filter out nulls');
+  assert.strictEqual(cardFiltered[0].tag, 'good', 'Non-null suggestion should remain');
+  const themeFiltered = await filterApp.getThemeSuggestions(5);
+  assert.strictEqual(themeFiltered.length, 1, 'Theme suggestions should filter out nulls');
+  assert.strictEqual(themeFiltered[0].tag, 'good', 'Theme should include non-null suggestion');
+
   console.log('All tests passed');
 })().catch(err => {
   console.error(err);


### PR DESCRIPTION
## Summary
- Refactor card and theme suggestion helpers to request suggestions in parallel and filter out missing values
- Test filtering of null suggestions using stubbed suggestion provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e677f79448322926aaaa5deb693d7