### PR TITLE
Optimize text search with precomputed index

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,6 +80,7 @@ class MemoryApp extends EventEmitter {
     if (basis && !card.description) {
       card.description = basis.slice(0, 100);
     }
+    card._updateSearchText();
     return card;
   }
 
@@ -160,10 +161,7 @@ class MemoryApp extends EventEmitter {
     const q = query.toLowerCase();
     const results = [];
     for (const card of this.cards.values()) {
-      const title = (card.title || '').toLowerCase();
-      const content = (card.content || '').toLowerCase();
-      const description = (card.description || '').toLowerCase();
-      if (title.includes(q) || content.includes(q) || description.includes(q)) {
+      if (card.searchText.includes(q)) {
         results.push(card);
       }
     }

--- a/src/card.js
+++ b/src/card.js
@@ -23,6 +23,7 @@ class Card {
     this.createdAt = createdAt;
     this.summary = summary;
     this.illustration = illustration;
+    this._updateSearchText();
   }
 
   addTag(tag) {
@@ -62,6 +63,14 @@ class Card {
     if (illustration !== undefined) {
       this.illustration = illustration;
     }
+    this._updateSearchText();
+  }
+
+  _updateSearchText() {
+    const parts = [this.title, this.content, this.description]
+      .filter(Boolean)
+      .map(s => s.toLowerCase());
+    this.searchText = parts.join(' ');
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -111,6 +111,7 @@ const { fetchSuggestion } = require('./src/suggestions');
   });
   assert.ok(aiCard.tags.size > 0, 'AI should add tags');
   assert.ok(aiCard.description, 'AI should add description');
+  assert.strictEqual(aiApp.searchByText('graph')[0].id, aiCard.id, 'Search should include AI-generated description');
   aiApp.setAIEnabled(false);
   const plainCard = await aiApp.createCard({ title: 'Plain', content: 'Just text' });
   assert.strictEqual(plainCard.tags.size, 0, 'No tags when AI disabled');


### PR DESCRIPTION
## Summary
- precompute `searchText` on cards for faster searches
- refresh search index after AI enrichment
- extend tests for AI-generated description search

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e81263dfc83228e3a5f69561b696f