### PR TITLE
feat: improve UI with searchable card layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15,9 +15,17 @@ const sampleCards = [
 
 const cardsContainer = document.getElementById('cards');
 const searchInput = document.getElementById('search');
+const themeToggle = document.getElementById('theme-toggle');
 
 function renderCards(cards = sampleCards) {
   cardsContainer.innerHTML = '';
+  if (!cards.length) {
+    const msg = document.createElement('p');
+    msg.id = 'no-results';
+    msg.textContent = 'No cards found';
+    cardsContainer.appendChild(msg);
+    return;
+  }
   for (const card of cards) {
     const el = document.createElement('div');
     el.className = 'card';
@@ -28,6 +36,16 @@ function renderCards(cards = sampleCards) {
         .map(t => `<span class="tag" data-tag="${t}">${t}</span>`)
         .join('')}</div>`;
     el.addEventListener('click', () => showCardSuggestions(card, el));
+    el.querySelectorAll('.tag').forEach(tagEl => {
+      tagEl.addEventListener('click', e => {
+        e.stopPropagation();
+        const tag = tagEl.dataset.tag;
+        searchInput.value = tag;
+        filterCards(tag);
+        const list = document.getElementById('suggestion-list');
+        list.innerHTML = '';
+      });
+    });
     cardsContainer.appendChild(el);
   }
 }
@@ -86,6 +104,20 @@ searchInput.addEventListener('input', e => {
   if (!e.target.value) {
     showThemeSuggestions();
   }
+});
+
+function setTheme(mode) {
+  document.body.classList.toggle('dark', mode === 'dark');
+  themeToggle.textContent = mode === 'dark' ? '☀️' : '🌙';
+  localStorage.setItem('theme', mode);
+}
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+setTheme(savedTheme);
+
+themeToggle.addEventListener('click', () => {
+  const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+  setTheme(newTheme);
 });
 
 renderCards();

--- a/public/app.js
+++ b/public/app.js
@@ -14,9 +14,11 @@ const sampleCards = [
 ];
 
 const cardsContainer = document.getElementById('cards');
+const searchInput = document.getElementById('search');
 
-function renderCards() {
-  for (const card of sampleCards) {
+function renderCards(cards = sampleCards) {
+  cardsContainer.innerHTML = '';
+  for (const card of cards) {
     const el = document.createElement('div');
     el.className = 'card';
     el.innerHTML = `
@@ -25,14 +27,28 @@ function renderCards() {
       <div class="tags">${card.tags
         .map(t => `<span class="tag" data-tag="${t}">${t}</span>`)
         .join('')}</div>`;
-    el.addEventListener('click', () => showCardSuggestions(card));
+    el.addEventListener('click', () => showCardSuggestions(card, el));
     cardsContainer.appendChild(el);
   }
 }
 
+function filterCards(query) {
+  const q = query.trim().toLowerCase();
+  const filtered = sampleCards.filter(
+    c =>
+      c.title.toLowerCase().includes(q) ||
+      c.tags.some(t => t.toLowerCase().includes(q))
+  );
+  renderCards(filtered);
+}
+
 const { fetchSuggestion } = window.suggestions;
 
-async function showCardSuggestions(card) {
+async function showCardSuggestions(card, element) {
+  document
+    .querySelectorAll('.card.selected')
+    .forEach(el => el.classList.remove('selected'));
+  element.classList.add('selected');
   const list = document.getElementById('suggestion-list');
   list.innerHTML = '';
   for (const tag of card.tags) {
@@ -62,6 +78,15 @@ async function showThemeSuggestions() {
     list.appendChild(li);
   }
 }
+
+searchInput.addEventListener('input', e => {
+  filterCards(e.target.value);
+  const list = document.getElementById('suggestion-list');
+  list.innerHTML = '';
+  if (!e.target.value) {
+    showThemeSuggestions();
+  }
+});
 
 renderCards();
 showThemeSuggestions();

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,10 @@
 <body>
   <header>
     <h1>MemoryApp Cards</h1>
-    <input type="search" id="search" placeholder="Search cards..." />
+    <div class="controls">
+      <input type="search" id="search" placeholder="Search cards..." />
+      <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
   <main class="layout">
     <div id="cards" class="card-grid"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -7,12 +7,17 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>MemoryApp Cards</h1>
-  <div id="cards" class="card-grid"></div>
-  <section id="suggestions">
-    <h2>Suggestions</h2>
-    <ul id="suggestion-list"></ul>
-  </section>
+  <header>
+    <h1>MemoryApp Cards</h1>
+    <input type="search" id="search" placeholder="Search cards..." />
+  </header>
+  <main class="layout">
+    <div id="cards" class="card-grid"></div>
+    <aside id="suggestions">
+      <h2>Suggestions</h2>
+      <ul id="suggestion-list"></ul>
+    </aside>
+  </main>
   <script src="suggestions.js"></script>
   <script src="app.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,28 @@
+
+:root {
+  --bg: #f0f0f0;
+  --text: #000;
+  --card-bg: #fff;
+  --card-border: #fcb900;
+  --tag-bg: #e0e0e0;
+  --suggestion-bg: #fff;
+}
+
 body {
   font-family: sans-serif;
-  background: #f0f0f0;
+  background: var(--bg);
+  color: var(--text);
   margin: 20px;
+  transition: background 0.3s, color 0.3s;
+}
+
+body.dark {
+  --bg: #1e1e1e;
+  --text: #f5f5f5;
+  --card-bg: #2a2a2a;
+  --card-border: #fcb900;
+  --tag-bg: #3a3a3a;
+  --suggestion-bg: #2a2a2a;
 }
 
 header {
@@ -10,6 +31,21 @@ header {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#theme-toggle {
+  margin-left: 1rem;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
 }
 
 #search {
@@ -36,13 +72,15 @@ header {
 
 .card {
   width: 200px;
-  background: #fff;
-  border: 3px solid #fcb900;
+  background: var(--card-bg);
+  border: 3px solid var(--card-border);
   border-radius: 10px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   padding: 1rem;
   cursor: pointer;
-  transition: transform 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s;
+  opacity: 0;
+  animation: fadeIn 0.3s forwards;
 }
 
 .card:hover {
@@ -63,20 +101,38 @@ header {
 
 .tag {
   display: inline-block;
-  background: #e0e0e0;
+  background: var(--tag-bg);
   border-radius: 8px;
   padding: 2px 6px;
   margin: 2px;
   font-size: 0.8rem;
+  cursor: pointer;
 }
 
 #suggestions {
   flex: 1;
-  background: #fff;
+  background: var(--suggestion-bg);
   border-radius: 10px;
   padding: 1rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   margin-top: 0;
   max-height: 500px;
   overflow-y: auto;
+}
+
+#no-results {
+  color: #888;
+}
+
+@media (max-width: 600px) {
+  .layout {
+    flex-direction: column;
+  }
+  #suggestions {
+    max-height: none;
+  }
+}
+
+@keyframes fadeIn {
+  to { opacity: 1; }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -4,6 +4,30 @@ body {
   margin: 20px;
 }
 
+header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+#search {
+  padding: 0.5rem;
+  font-size: 1rem;
+  flex: 1;
+  max-width: 300px;
+}
+
+.layout {
+  display: flex;
+  gap: 2rem;
+}
+
+#cards {
+  flex: 3;
+}
+
 .card-grid {
   display: flex;
   flex-wrap: wrap;
@@ -25,6 +49,10 @@ body {
   transform: scale(1.05);
 }
 
+.card.selected {
+  box-shadow: 0 0 0 3px #007bff;
+}
+
 .card h3 {
   margin-top: 0;
 }
@@ -43,5 +71,12 @@ body {
 }
 
 #suggestions {
-  margin-top: 2rem;
+  flex: 1;
+  background: #fff;
+  border-radius: 10px;
+  padding: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-top: 0;
+  max-height: 500px;
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- add header with card search field
- lay out card grid and suggestions side-by-side
- highlight selected cards and filter cards by text or tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e909dee2083228de6de0a5529d31b