### PR TITLE
feat: allow model selection for summaries and images

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,37 +1,82 @@
-const sampleCards = [
-  {
-    id: '1',
-    title: 'Sample Note',
-    description: 'Demo card used for the UI prototype.',
-    tags: ['demo', 'sample']
-  },
-  {
-    id: '2',
-    title: 'JavaScript',
-    description: 'Notes about JS.',
-    tags: ['JavaScript', 'code']
-  }
-];
+let cards = JSON.parse(localStorage.getItem('cards') || '[]');
+if (cards.length === 0) {
+  cards = [
+    {
+      id: '1',
+      title: 'Sample Note',
+      description: 'Demo card used for the UI prototype.',
+      tags: ['demo', 'sample']
+    },
+    {
+      id: '2',
+      title: 'JavaScript',
+      description: 'Notes about JS.',
+      tags: ['JavaScript', 'code']
+    }
+  ];
+}
+let nextId = cards.reduce((m, c) => Math.max(m, Number(c.id)), 0) + 1;
 
 const cardsContainer = document.getElementById('cards');
 const searchInput = document.getElementById('search');
 const themeToggle = document.getElementById('theme-toggle');
+const addForm = document.getElementById('add-card-form');
+const titleInput = document.getElementById('new-title');
+const descInput = document.getElementById('new-description');
+const tagsInput = document.getElementById('new-tags');
+const apiKeyInput = document.getElementById('api-key');
+const summaryModelSelect = document.getElementById('summary-model');
+const imageModelSelect = document.getElementById('image-model');
 
-function renderCards(cards = sampleCards) {
+apiKeyInput.value = localStorage.getItem('hfKey') || '';
+apiKeyInput.addEventListener('input', () =>
+  localStorage.setItem('hfKey', apiKeyInput.value.trim())
+);
+summaryModelSelect.value =
+  localStorage.getItem('summaryModel') || 'google/flan-t5-base';
+imageModelSelect.value =
+  localStorage.getItem('imageModel') ||
+  'stabilityai/stable-diffusion-xl-base-1.0';
+summaryModelSelect.addEventListener('change', () =>
+  localStorage.setItem('summaryModel', summaryModelSelect.value)
+);
+imageModelSelect.addEventListener('change', () =>
+  localStorage.setItem('imageModel', imageModelSelect.value)
+);
+
+function getApiKey() {
+  return apiKeyInput.value.trim();
+}
+
+function getSummaryModel() {
+  return summaryModelSelect.value;
+}
+
+function getImageModel() {
+  return imageModelSelect.value;
+}
+
+function saveCards() {
+  localStorage.setItem('cards', JSON.stringify(cards));
+}
+
+function renderCards(list = cards) {
   cardsContainer.innerHTML = '';
-  if (!cards.length) {
+  if (!list.length) {
     const msg = document.createElement('p');
     msg.id = 'no-results';
     msg.textContent = 'No cards found';
     cardsContainer.appendChild(msg);
     return;
   }
-  for (const card of cards) {
+  for (const card of list) {
     const el = document.createElement('div');
     el.className = 'card';
     el.innerHTML = `
       <h3>${card.title}</h3>
+      ${card.image ? `<img src="${card.image}" alt="illustration">` : ''}
       <p>${card.description}</p>
+      ${card.summary ? `<p class="summary">${card.summary}</p>` : ''}
       <div class="tags">${card.tags
         .map(t => `<span class="tag" data-tag="${t}">${t}</span>`)
         .join('')}</div>`;
@@ -52,7 +97,7 @@ function renderCards(cards = sampleCards) {
 
 function filterCards(query) {
   const q = query.trim().toLowerCase();
-  const filtered = sampleCards.filter(
+  const filtered = cards.filter(
     c =>
       c.title.toLowerCase().includes(q) ||
       c.tags.some(t => t.toLowerCase().includes(q))
@@ -79,7 +124,7 @@ async function showCardSuggestions(card, element) {
 
 async function showThemeSuggestions() {
   const counts = {};
-  for (const card of sampleCards) {
+  for (const card of cards) {
     for (const tag of card.tags) {
       counts[tag] = (counts[tag] || 0) + 1;
     }
@@ -120,5 +165,107 @@ themeToggle.addEventListener('click', () => {
   setTheme(newTheme);
 });
 
+async function summarizeText(text) {
+  const key = getApiKey();
+  const model = getSummaryModel();
+  if (!key || !text) {
+    return text.length > 100 ? text.slice(0, 100) + '…' : text;
+  }
+  try {
+    const res = await fetch(
+      `https://api-inference.huggingface.co/models/${encodeURIComponent(
+        model
+      )}?wait_for_model=true`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${key}`
+        },
+        body: JSON.stringify({ inputs: text })
+      }
+    );
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    const data = await res.json();
+    return data[0]?.summary_text?.trim() || '';
+  } catch (err) {
+    console.error('summary failed', err);
+    return text.length > 100 ? text.slice(0, 100) + '…' : text;
+  }
+}
+
+async function generateImage(prompt) {
+  const key = getApiKey();
+  const fallback = `https://source.unsplash.com/200x200/?${encodeURIComponent(
+    prompt || 'abstract'
+  )}`;
+  const model = getImageModel();
+  const styledPrompt = `a cartoon art deco illustration of ${prompt}`;
+  if (!key || !prompt) {
+    return fallback;
+  }
+  try {
+    const res = await fetch(
+      `https://api-inference.huggingface.co/models/${encodeURIComponent(
+        model
+      )}?wait_for_model=true`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${key}`
+        },
+        body: JSON.stringify({ inputs: styledPrompt })
+      }
+    );
+    if (!res.ok || !res.headers.get('content-type')?.startsWith('image/')) {
+      throw new Error(await res.text());
+    }
+    const arrayBuffer = await res.arrayBuffer();
+    const base64 = btoa(
+      String.fromCharCode(...new Uint8Array(arrayBuffer))
+    );
+    return `data:image/png;base64,${base64}`;
+  } catch (err) {
+    console.error('image failed', err);
+    return fallback;
+  }
+}
+
+addForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const title = titleInput.value.trim();
+  const description = descInput.value.trim();
+  const tags = tagsInput.value
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean);
+  if (!title) {
+    return;
+  }
+  const summary = await summarizeText(description);
+  const image = await generateImage(description || tags.join(', '));
+  cards.push({ id: String(nextId++), title, description, tags, summary, image });
+  saveCards();
+  renderCards();
+  showThemeSuggestions();
+  addForm.reset();
+});
+
 renderCards();
 showThemeSuggestions();
+
+(async function enrichExisting() {
+  for (const card of cards) {
+    if (!card.summary && card.description) {
+      card.summary = await summarizeText(card.description);
+    }
+    if (!card.image && (card.description || card.tags.length)) {
+      card.image = await generateImage(card.description || card.tags.join(', '));
+    }
+  }
+  saveCards();
+  renderCards();
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,28 @@
   <header>
     <h1>MemoryApp Cards</h1>
     <div class="controls">
+      <input type="password" id="api-key" placeholder="Hugging Face API Token" />
+      <select id="summary-model">
+        <option value="google/flan-t5-base">Flan-T5</option>
+        <option value="google/mt5-base">mT5</option>
+        <option value="sshleifer/distilbart-cnn-12-6">DistilBART</option>
+      </select>
+      <select id="image-model">
+        <option value="stabilityai/stable-diffusion-xl-base-1.0">SDXL</option>
+        <option value="runwayml/stable-diffusion-v1-5">SD 1.5</option>
+      </select>
       <input type="search" id="search" placeholder="Search cards..." />
       <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
+  <section id="add-card">
+    <form id="add-card-form">
+      <input type="text" id="new-title" placeholder="Title" required />
+      <input type="text" id="new-description" placeholder="Description" />
+      <input type="text" id="new-tags" placeholder="Tags (comma separated)" />
+      <button type="submit">Add Card</button>
+    </form>
+  </section>
   <main class="layout">
     <div id="cards" class="card-grid"></div>
     <aside id="suggestions">

--- a/public/style.css
+++ b/public/style.css
@@ -34,6 +34,26 @@ header {
   gap: 0.5rem;
 }
 
+#add-card {
+  margin-bottom: 1rem;
+}
+
+#add-card-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+#add-card-form input {
+  padding: 0.5rem;
+  flex: 1;
+  min-width: 120px;
+}
+
+#add-card-form button {
+  padding: 0.5rem 1rem;
+}
+
 .controls {
   display: flex;
   align-items: center;
@@ -53,6 +73,17 @@ header {
   font-size: 1rem;
   flex: 1;
   max-width: 300px;
+}
+
+#api-key {
+  padding: 0.5rem;
+  font-size: 1rem;
+  max-width: 200px;
+}
+
+.controls select {
+  padding: 0.5rem;
+  font-size: 1rem;
 }
 
 .layout {
@@ -81,6 +112,17 @@ header {
   transition: transform 0.2s, box-shadow 0.2s;
   opacity: 0;
   animation: fadeIn 0.3s forwards;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.summary {
+  font-style: italic;
+  margin-top: 0.5rem;
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
- add dropdowns to choose summarization and image generation models
- persist selected models and call Hugging Face accordingly
- request art-deco style illustrations via the chosen image model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e97cb352483228284e76af3a95429