### PR TITLE
Handle processCard errors during sync processing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -130,8 +130,12 @@ class MemoryApp extends EventEmitter {
           .then(() => this.emit('cardProcessed', card))
           .catch(err => this.emit('error', err));
       } else {
-        await this.processCard(card);
-        this.emit('cardProcessed', card);
+        try {
+          await this.processCard(card);
+          this.emit('cardProcessed', card);
+        } catch (err) {
+          this.emit('error', err);
+        }
       }
     }
     if (this.db) {


### PR DESCRIPTION
## Summary
- wrap synchronous `processCard` call with try/catch to emit errors and only signal `cardProcessed` on success
- continue saving cards to the database even if processing fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1d4403f88322912bc27d9156b725