### PR TITLE
Use XML parser for RSS suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "better-sqlite3": "^9.6.0"
+        "better-sqlite3": "^9.6.0",
+        "fast-xml-parser": "^4.5.3"
       }
     },
     "node_modules/base64-js": {
@@ -142,6 +143,24 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -407,6 +426,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/tar-fs": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "better-sqlite3": "^9.6.0"
+    "better-sqlite3": "^9.6.0",
+    "fast-xml-parser": "^4.5.3"
   }
 }

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,3 +1,4 @@
+const { XMLParser } = require('fast-xml-parser');
 const FETCH_TIMEOUT_MS = 1000;
 
 async function timedFetch(url, options = {}, timeout = FETCH_TIMEOUT_MS) {
@@ -56,15 +57,22 @@ async function fetchFromRSS(tag) {
     const res = await timedFetch(url);
     if (res.ok) {
       const text = await res.text();
-      const match = text.match(/<item>\s*<title>([^<]+)<\/title>\s*<link>([^<]+)<\/link>/i);
-      if (match) {
-        return {
-          tag,
-          title: match[1],
-          description: '',
-          url: match[2],
-          source: 'rss',
-        };
+      try {
+        const parser = new XMLParser();
+        const parsed = parser.parse(text);
+        const items = parsed && parsed.rss && parsed.rss.channel && parsed.rss.channel.item;
+        const first = Array.isArray(items) ? items[0] : items;
+        if (first && first.title && first.link) {
+          return {
+            tag,
+            title: first.title,
+            description: '',
+            url: first.link,
+            source: 'rss',
+          };
+        }
+      } catch (e) {
+        return null;
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- replace regex-based RSS parsing with fast-xml-parser and return first item's title and link
- handle RSS parsing errors with try/catch returning null
- add fast-xml-parser dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1d5301a483228de7e6ce79e865c2