### PR TITLE
Make YouTube API key configurable for video suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ When a `HUGGINGFACE_API_KEY` environment variable is present, the app will query
 
 The prototype also experiments with web suggestions: when enabled, the app will gather card tags and query public sources such as RSS feeds and Reddit to propose related content, with YouTube used for video cards and ArXiv for academic material. Suggestions can be turned off for privacy or offline use. The API now exposes helpers to retrieve recommendations for a selected card or to surface theme suggestions from the most common tags. A small static demo in the `public/` folder presents a Pokémon-style card layout and populates a suggestion list using these sources whenever a card or theme is selected.
 
+### YouTube API key
+
+Video suggestions rely on the YouTube Data API. Provide a key by setting `window.YT_API_KEY` in your browser console, for example:
+
+```js
+window.YT_API_KEY = 'your-key-here';
+```
+
+If no key is present, the demo will prompt for one when a YouTube request is made.
+
 ### Running tests
 
 ```

--- a/public/suggestions.js
+++ b/public/suggestions.js
@@ -64,9 +64,23 @@ async function fetchFromRSS(tag) {
   return null;
 }
 
+let cachedYTKey;
+function getYouTubeApiKey() {
+  if (cachedYTKey !== undefined) {
+    return cachedYTKey;
+  }
+  if (typeof window !== 'undefined') {
+    cachedYTKey = window.YT_API_KEY || window.prompt('Enter YouTube API key');
+    window.YT_API_KEY = cachedYTKey;
+    return cachedYTKey;
+  }
+  cachedYTKey = null;
+  return null;
+}
+
 async function fetchFromYouTube(tag) {
   try {
-    const apiKey = process.env.YOUTUBE_API_KEY;
+    const apiKey = getYouTubeApiKey();
     const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&maxResults=1&q=${encodeURIComponent(tag)}${apiKey ? `&key=${apiKey}` : ''}`;
     const res = await fetch(url);
     if (res.ok) {


### PR DESCRIPTION
## Summary
- Allow YouTube suggestions to use a user-provided API key via `window.YT_API_KEY` or a prompt
- Document how to set the YouTube API key for video suggestions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1d538ba88322900dec7526561c9c