### PR TITLE
chore: support fetch in older Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "better-sqlite3": "^9.6.0"
+        "better-sqlite3": "^9.6.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/base64-js": {
@@ -239,6 +243,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -436,6 +460,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -453,6 +483,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
-    "better-sqlite3": "^9.6.0"
+    "better-sqlite3": "^9.6.0",
+    "node-fetch": "^2.6.7"
   }
 }

--- a/src/ai.js
+++ b/src/ai.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 
+if (typeof fetch === 'undefined') {
+  global.fetch = require('node-fetch');
+}
+
 const HF_MODELS = {
   summarization: 'google/mt5-base',
   chat: 'HuggingFaceH4/zephyr-7b-beta',

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,3 +1,7 @@
+if (typeof fetch === 'undefined') {
+  global.fetch = require('node-fetch');
+}
+
 const FETCH_TIMEOUT_MS = 1000;
 
 async function timedFetch(url, options = {}, timeout = FETCH_TIMEOUT_MS) {


### PR DESCRIPTION
## Summary
- define Node 18+ support and include node-fetch dependency
- ensure AI and suggestion modules polyfill `fetch` with node-fetch when unavailable

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1d54a97083228088ebd56691815a