### PR TITLE
chore: fix lockfile and fromJSON style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^9.6.0",
+        "fast-xml-parser": "^4.5.3",
         "node-fetch": "^2.6.7"
       },
       "engines": {
-        "node": ">=18",
-        "fast-xml-parser": "^4.5.3"
+        "node": ">=18"
       }
     },
     "node_modules/base64-js": {

--- a/src/app.js
+++ b/src/app.js
@@ -529,7 +529,7 @@ class MemoryApp extends EventEmitter {
   static fromJSON(data) {
     const app = new MemoryApp();
     app.aiEnabled = false;
-      for (const cardData of data.cards || []) {
+    for (const cardData of data.cards || []) {
       if (cardData.tags) {
         cardData.tags = cardData.tags.map(t => t.toLowerCase());
       }


### PR DESCRIPTION
## Summary
- ensure fast-xml-parser is declared as dependency in lockfile
- tidy fromJSON indentation for readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1990803c832282042b528214efe2