### PR TITLE
feat: add deck sidebar and graph view

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15,11 +15,20 @@ if (cards.length === 0) {
     }
   ];
 }
+cards = cards.map(c => ({
+  ...c,
+  tags: c.tags || [],
+  decks: c.decks || ['default'],
+  favorite: c.favorite || false
+}));
 let nextId = cards.reduce((m, c) => Math.max(m, Number(c.id)), 0) + 1;
 
 const cardsContainer = document.getElementById('cards');
 const searchInput = document.getElementById('search');
 const themeToggle = document.getElementById('theme-toggle');
+const viewToggle = document.getElementById('view-toggle');
+const deckList = document.getElementById('deck-list');
+const graphContainer = document.getElementById('graph');
 const addForm = document.getElementById('add-card-form');
 const titleInput = document.getElementById('new-title');
 const descInput = document.getElementById('new-description');
@@ -28,6 +37,9 @@ const apiKeyInput = document.getElementById('api-key');
 const summaryModelSelect = document.getElementById('summary-model');
 const imageModelSelect = document.getElementById('image-model');
 const recordBtn = document.getElementById('record-audio');
+
+let selectedDeck = 'all';
+let currentView = 'cards';
 
 apiKeyInput.value = localStorage.getItem('hfKey') || '';
 apiKeyInput.addEventListener('input', () =>
@@ -73,10 +85,11 @@ function renderCards(list = cards) {
   for (const card of list) {
     const el = document.createElement('div');
     el.className = 'card';
+    el.dataset.id = card.id;
     el.innerHTML = `
       <h3>${card.title}</h3>
       ${card.image ? `<img src="${card.image}" alt="illustration">` : ''}
-      <p>${card.description}</p>
+      <p class="desc">${card.description}</p>
       ${card.summary ? `<p class="summary">${card.summary}</p>` : ''}
       <div class="tags">${card.tags
         .map(t => `<span class="tag" data-tag="${t}">${t}</span>`)
@@ -87,23 +100,174 @@ function renderCards(list = cards) {
         e.stopPropagation();
         const tag = tagEl.dataset.tag;
         searchInput.value = tag;
-        filterCards(tag);
+        applyFilters();
         const list = document.getElementById('suggestion-list');
         list.innerHTML = '';
       });
     });
+    const controls = document.createElement('div');
+    controls.className = 'card-controls';
+    controls.innerHTML = `
+      <button class="edit">Edit</button>
+      <button class="fav ${card.favorite ? 'favorite' : ''}">${card.favorite ? '★' : '☆'}</button>
+      <button class="del">Delete</button>`;
+    controls.querySelector('.edit').addEventListener('click', e => {
+      e.stopPropagation();
+      editCard(card);
+    });
+    controls.querySelector('.fav').addEventListener('click', e => {
+      e.stopPropagation();
+      toggleFavorite(card, controls.querySelector('.fav'));
+    });
+    controls.querySelector('.del').addEventListener('click', e => {
+      e.stopPropagation();
+      deleteCard(card.id);
+    });
+    el.appendChild(controls);
     cardsContainer.appendChild(el);
   }
 }
 
-function filterCards(query) {
+function editCard(card) {
+  const el = document.querySelector(`.card[data-id="${card.id}"]`);
+  if (!el) return;
+  const desc = el.querySelector('.desc');
+  const tagsDiv = el.querySelector('.tags');
+  const descInput = document.createElement('textarea');
+  descInput.value = card.description;
+  const tagsInput = document.createElement('input');
+  tagsInput.value = card.tags.join(', ');
+  desc.replaceWith(descInput);
+  tagsDiv.replaceWith(tagsInput);
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  saveBtn.className = 'save-edit';
+  el.appendChild(saveBtn);
+  saveBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    card.description = descInput.value.trim();
+    card.tags = tagsInput.value
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+    saveCards();
+    renderDecks();
+    applyFilters();
+    showThemeSuggestions();
+  });
+}
+
+function toggleFavorite(card, btn) {
+  card.favorite = !card.favorite;
+  if (card.favorite) {
+    if (!card.decks.includes('favorites')) {
+      card.decks.push('favorites');
+    }
+  } else {
+    card.decks = card.decks.filter(d => d !== 'favorites');
+  }
+  btn.textContent = card.favorite ? '★' : '☆';
+  btn.classList.toggle('favorite', card.favorite);
+  saveCards();
+  renderDecks();
+}
+
+function deleteCard(id) {
+  cards = cards.filter(c => c.id !== id);
+  saveCards();
+  renderDecks();
+  applyFilters();
+  showThemeSuggestions();
+}
+
+function filterCards(query, deck = selectedDeck) {
   const q = query.trim().toLowerCase();
-  const filtered = cards.filter(
-    c =>
+  return cards.filter(c => {
+    const matchesQuery =
       c.title.toLowerCase().includes(q) ||
-      c.tags.some(t => t.toLowerCase().includes(q))
-  );
-  renderCards(filtered);
+      c.tags.some(t => t.toLowerCase().includes(q));
+    const matchesDeck =
+      deck === 'all' ||
+      (c.decks && c.decks.includes(deck)) ||
+      (deck === 'favorites' && c.favorite);
+    return matchesQuery && matchesDeck;
+  });
+}
+
+function applyFilters() {
+  const filtered = filterCards(searchInput.value, selectedDeck);
+  if (currentView === 'graph') {
+    renderGraph(filtered);
+  } else {
+    renderCards(filtered);
+  }
+}
+
+function renderDecks() {
+  const deckSet = new Set();
+  for (const card of cards) {
+    (card.decks || []).forEach(d => deckSet.add(d));
+  }
+  deckList.innerHTML = '';
+  const makeItem = (name, label) => {
+    const li = document.createElement('li');
+    li.textContent = label || name;
+    li.dataset.deck = name;
+    if (selectedDeck === name) li.classList.add('active');
+    deckList.appendChild(li);
+  };
+  makeItem('all', 'All');
+  for (const d of deckSet) {
+    makeItem(d);
+  }
+  if (cards.some(c => c.favorite)) {
+    makeItem('favorites', 'Favorites');
+  }
+}
+
+function renderGraph(list) {
+  graphContainer.innerHTML = '';
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('height', '100%');
+  const width = graphContainer.clientWidth || 600;
+  const height = graphContainer.clientHeight || 400;
+  const radius = Math.min(width, height) / 2 - 40;
+  list.forEach((card, idx) => {
+    const angle = (2 * Math.PI * idx) / list.length;
+    card._x = width / 2 + radius * Math.cos(angle);
+    card._y = height / 2 + radius * Math.sin(angle);
+  });
+  for (let i = 0; i < list.length; i++) {
+    for (let j = i + 1; j < list.length; j++) {
+      if (list[i].tags.some(t => list[j].tags.includes(t))) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', list[i]._x);
+        line.setAttribute('y1', list[i]._y);
+        line.setAttribute('x2', list[j]._x);
+        line.setAttribute('y2', list[j]._y);
+        line.setAttribute('stroke', '#888');
+        svg.appendChild(line);
+      }
+    }
+  }
+  for (const card of list) {
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', card._x);
+    circle.setAttribute('cy', card._y);
+    circle.setAttribute('r', 20);
+    circle.setAttribute('fill', '#fcb900');
+    circle.setAttribute('stroke', '#333');
+    svg.appendChild(circle);
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', card._x);
+    text.setAttribute('y', card._y + 4);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('font-size', '10');
+    text.textContent = card.title.slice(0, 10);
+    svg.appendChild(text);
+  }
+  graphContainer.appendChild(svg);
 }
 
 const { fetchSuggestion } = window.suggestions;
@@ -144,12 +308,29 @@ async function showThemeSuggestions() {
 }
 
 searchInput.addEventListener('input', e => {
-  filterCards(e.target.value);
+  applyFilters();
   const list = document.getElementById('suggestion-list');
   list.innerHTML = '';
   if (!e.target.value) {
     showThemeSuggestions();
   }
+});
+
+deckList.addEventListener('click', e => {
+  if (e.target.matches('li')) {
+    selectedDeck = e.target.dataset.deck;
+    renderDecks();
+    applyFilters();
+  }
+});
+
+viewToggle.addEventListener('click', () => {
+  currentView = currentView === 'cards' ? 'graph' : 'cards';
+  viewToggle.textContent =
+    currentView === 'cards' ? 'Graph View' : 'Card View';
+  cardsContainer.classList.toggle('hidden', currentView !== 'cards');
+  graphContainer.classList.toggle('hidden', currentView !== 'graph');
+  applyFilters();
 });
 
 function setTheme(mode) {
@@ -248,9 +429,11 @@ addForm.addEventListener('submit', async e => {
   }
   const summary = await summarizeText(description);
   const image = await generateImage(description || tags.join(', '));
-  cards.push({ id: String(nextId++), title, description, tags, summary, image });
+  const deckForNew = selectedDeck === 'all' ? ['default'] : [selectedDeck];
+  cards.push({ id: String(nextId++), title, description, tags, summary, image, decks: deckForNew, favorite: false });
   saveCards();
-  renderCards();
+  renderDecks();
+  applyFilters();
   showThemeSuggestions();
   addForm.reset();
 });
@@ -277,9 +460,12 @@ if (recordBtn) {
           body: JSON.stringify({ audio: base64 })
         });
         const card = await response.json();
+        card.decks = card.decks || (selectedDeck === 'all' ? ['default'] : [selectedDeck]);
+        card.favorite = false;
         cards.push(card);
         saveCards();
-        renderCards();
+        renderDecks();
+        applyFilters();
       };
       mediaRecorder.start();
       recordBtn.textContent = 'Stop';
@@ -291,7 +477,8 @@ if (recordBtn) {
   });
 }
 
-renderCards();
+renderDecks();
+applyFilters();
 showThemeSuggestions();
 
 (async function enrichExisting() {
@@ -304,5 +491,6 @@ showThemeSuggestions();
     }
   }
   saveCards();
-  renderCards();
+  renderDecks();
+  applyFilters();
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
         <option value="runwayml/stable-diffusion-v1-5">SD 1.5</option>
       </select>
       <input type="search" id="search" placeholder="Search cards..." />
+      <button id="view-toggle">Graph View</button>
       <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
   </header>
@@ -34,7 +35,12 @@
     <button id="record-audio">Record Audio Note</button>
   </section>
   <main class="layout">
+    <aside id="deck-sidebar">
+      <h2>Decks</h2>
+      <ul id="deck-list"></ul>
+    </aside>
     <div id="cards" class="card-grid"></div>
+    <div id="graph" class="graph-view hidden"></div>
     <aside id="suggestions">
       <h2>Suggestions</h2>
       <ul id="suggestion-list"></ul>

--- a/public/style.css
+++ b/public/style.css
@@ -91,8 +91,43 @@ header {
   gap: 2rem;
 }
 
+#deck-sidebar {
+  flex: 1;
+  max-width: 200px;
+}
+
+#deck-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#deck-list li {
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+#deck-list li.active {
+  background: var(--card-border);
+  color: var(--bg);
+}
+
 #cards {
   flex: 3;
+}
+
+#graph {
+  flex: 3;
+  height: 400px;
+  border: 3px solid var(--card-border);
+  border-radius: 10px;
+  background: var(--card-bg);
+}
+
+.graph-view.hidden,
+#cards.hidden {
+  display: none;
 }
 
 .card-grid {
@@ -149,6 +184,21 @@ header {
   margin: 2px;
   font-size: 0.8rem;
   cursor: pointer;
+}
+
+.card-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.card-controls button {
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.card-controls .fav.favorite {
+  color: gold;
 }
 
 #suggestions {


### PR DESCRIPTION
## Summary
- add deck sidebar and graph/card view toggle
- support per-card editing, favoriting and deletion
- link search and deck filters to grid and graph rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895cad62b808322bd540f1b2cc8f024