### PR TITLE
Add link type controls and card visuals

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ const defaultCards = [
     description: 'Demo card used for the UI prototype.',
     tags: ['demo', 'sample'],
     decks: [],
+    type: 'text',
   },
   {
     id: '2',
@@ -21,6 +22,7 @@ const defaultCards = [
     description: 'Notes about JS.',
     tags: ['JavaScript', 'code'],
     decks: [],
+    type: 'text',
   },
 ];
 
@@ -132,8 +134,12 @@ export default function App() {
     setQuickAddInitial(s.title);
   };
 
-  const handleLinkCreate = (from, to) => {
-    setLinks(prev => [...prev, { id: Date.now().toString(), from, to }]);
+  const handleLinkCreate = (from, to, type) => {
+    setLinks(prev => [...prev, { id: Date.now().toString(), from, to, type }]);
+  };
+
+  const handleLinkEdit = (id, type) => {
+    setLinks(prev => prev.map(l => (l.id === id ? { ...l, type } : l)));
   };
 
   const toggleWebSuggestions = () => {
@@ -160,7 +166,12 @@ export default function App() {
         </div>
         <QuickAdd onAdd={addCard} initial={quickAddInitial} />
         {showGraph ? (
-          <GraphView cards={cards} links={links} onLink={handleLinkCreate} />
+          <GraphView
+            cards={cards}
+            links={links}
+            onLink={handleLinkCreate}
+            onLinkEdit={handleLinkEdit}
+          />
         ) : (
           <CardGrid
             cards={filtered}

--- a/frontend/src/components/CardGrid.jsx
+++ b/frontend/src/components/CardGrid.jsx
@@ -14,11 +14,11 @@ const tagColors = {
   code: 'bg-blue-200',
 };
 
-const tagIcons = {
-  demo: '🎴',
-  sample: '📘',
-  javascript: '💻',
-  code: '🧩',
+const typeIcons = {
+  text: '📝',
+  image: '🖼️',
+  link: '🔗',
+  file: '📁',
 };
 
 export default function CardGrid({ cards, onSelect, onEdit, onDelete, onFav }) {
@@ -39,10 +39,15 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, onFav }) {
             <button onClick={e => { e.stopPropagation(); onFav && onFav(card); }} className="text-xs">⭐</button>
           </div>
           <h3 className="text-lg font-semibold mb-2 flex items-center">
-            <span className="mr-1">{tagIcons[card.tags[0]?.toLowerCase()] || '📝'}</span>
+            <span className="mr-1">{typeIcons[card.contentType || card.type || 'text'] || '📝'}</span>
             {card.title}
           </h3>
-          {card.image && <img src={card.image} alt="illustration" className="mb-2" />}
+          {card.illustration && (
+            <img src={card.illustration} alt="illustration" className="mb-2" />
+          )}
+          {!card.illustration && card.image && (
+            <img src={card.image} alt="illustration" className="mb-2" />
+          )}
           <p>{card.description}</p>
           {card.summary && <p className="text-sm text-gray-600">{card.summary}</p>}
           <div className="mt-2 space-x-1">

--- a/frontend/src/components/GraphView.jsx
+++ b/frontend/src/components/GraphView.jsx
@@ -2,9 +2,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-export default function GraphView({ cards, links, onLink }) {
+export default function GraphView({ cards, links, onLink, onLinkEdit }) {
   const [deckFilter, setDeckFilter] = useState('');
   const [tagFilter, setTagFilter] = useState('');
+  const [linkFilter, setLinkFilter] = useState('');
 
   const filtered = useMemo(
     () =>
@@ -21,27 +22,48 @@ export default function GraphView({ cards, links, onLink }) {
       filtered.map(c => ({
         id: c.id,
         position: { x: Math.random() * 400, y: Math.random() * 400 },
-        data: { label: `${c.title}${c.decks?.length ? ` [${c.decks.length}]` : ''}` },
+        data: {
+          label: `${c.title}${c.decks?.length > 1 ? ' 🔁' : ''}`,
+        },
       })),
     [filtered]
   );
   const edges = useMemo(
     () =>
       (links || [])
-        .filter(l => filtered.some(c => c.id === l.from) && filtered.some(c => c.id === l.to))
-        .map(l => ({ id: l.id, source: l.from, target: l.to })),
-    [links, filtered]
+        .filter(
+          l =>
+            (!linkFilter || l.type === linkFilter) &&
+            filtered.some(c => c.id === l.from) &&
+            filtered.some(c => c.id === l.to)
+        )
+        .map(l => ({ id: l.id, source: l.from, target: l.to, label: l.type, data: { type: l.type } })),
+    [links, filtered, linkFilter]
   );
 
   const handleConnect = useCallback(
     params => {
-      onLink && onLink(params.source, params.target);
+      const type = prompt('Link type (e.g., inspires, completes)', 'related');
+      if (type && onLink) {
+        onLink(params.source, params.target, type);
+      }
     },
     [onLink]
   );
 
+  const handleEdgeClick = useCallback(
+    (_, edge) => {
+      const type = prompt('Edit link type', edge.data?.type || edge.label || '');
+      if (type !== null && onLinkEdit) {
+        onLinkEdit(edge.id, type);
+      }
+    },
+    [onLinkEdit]
+  );
+
   const deckOptions = Array.from(new Set(cards.flatMap(c => c.decks || [])));
   const tagOptions = Array.from(new Set(cards.flatMap(c => c.tags || [])));
+  const linkTypeOptions = Array.from(new Set((links || []).map(l => l.type).filter(Boolean)));
 
   return (
     <div>
@@ -70,9 +92,27 @@ export default function GraphView({ cards, links, onLink }) {
             </option>
           ))}
         </select>
+        <select
+          value={linkFilter}
+          onChange={e => setLinkFilter(e.target.value)}
+          className="border px-2"
+        >
+          <option value="">All Link Types</option>
+          {linkTypeOptions.map(t => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
       </div>
       <div style={{ width: '100%', height: 400 }}>
-        <ReactFlow nodes={nodes} edges={edges} onConnect={handleConnect} fitView>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onConnect={handleConnect}
+          onEdgeClick={handleEdgeClick}
+          fitView
+        >
           <Background />
           <Controls />
         </ReactFlow>

--- a/frontend/src/components/QuickAdd.jsx
+++ b/frontend/src/components/QuickAdd.jsx
@@ -20,6 +20,7 @@ export default function QuickAdd({ onAdd, initial }) {
       setPending({
         title: text.slice(0, 20),
         description: text,
+        type: 'text',
         decks: parseDecks(decksInput),
       });
     }


### PR DESCRIPTION
## Summary
- support annotated links with type prompts and editing in graph view
- allow filtering graph edges by link type and mark multi-deck cards
- display content-type icons and AI illustrations in the card grid

## Testing
- `npm test` *(frontend)*
- `npm run lint` *(frontend)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896230d1854832295ba9a5862cc446e