### PR TITLE
feat: integrate semantic search, media, chat, export, and graph enhancements

### DIFF
--- a/frontend/src/components/CardGrid.jsx
+++ b/frontend/src/components/CardGrid.jsx
@@ -1,27 +1,15 @@
 import React from 'react';
-
-const tagStyles = {
-  demo: 'border-red-400',
-  sample: 'border-yellow-400',
-  javascript: 'border-green-400',
-  code: 'border-blue-400',
-};
-
-const tagColors = {
-  demo: 'bg-red-200',
-  sample: 'bg-yellow-200',
-  javascript: 'bg-green-200',
-  code: 'bg-blue-200',
-};
+import { tagColor } from '../tagColors';
 
 const typeIcons = {
   text: '📝',
   image: '🖼️',
   link: '🔗',
   file: '📁',
+  video: '🎬',
 };
 
-export default function CardGrid({ cards, onSelect, onEdit, onDelete, onFav }) {
+export default function CardGrid({ cards, onSelect, onEdit, onDelete }) {
   if (!cards.length) {
     return <p className="text-gray-500">No cards found</p>;
   }
@@ -30,13 +18,13 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, onFav }) {
       {cards.map(card => (
         <div
           key={card.id}
-          className={`group relative bg-white border-4 p-4 rounded-xl cursor-pointer shadow-md hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition ${tagStyles[card.tags[0]?.toLowerCase()] || 'border-gray-300'}`}
+          className="group relative bg-white border-4 p-4 rounded-xl cursor-pointer shadow-md hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition"
+          style={{ borderColor: card.tags[0] ? tagColor(card.tags[0]) : '#d1d5db' }}
           onClick={() => onSelect(card)}
         >
           <div className="absolute top-1 right-1 space-x-1 opacity-0 group-hover:opacity-100">
             <button onClick={e => { e.stopPropagation(); onEdit && onEdit(card); }} className="text-xs">✏️</button>
             <button onClick={e => { e.stopPropagation(); onDelete && onDelete(card.id); }} className="text-xs">🗑️</button>
-            <button onClick={e => { e.stopPropagation(); onFav && onFav(card); }} className="text-xs">⭐</button>
           </div>
           <h3 className="text-lg font-semibold mb-2 flex items-center">
             <span className="mr-1">{typeIcons[card.contentType || card.type || 'text'] || '📝'}</span>
@@ -48,13 +36,22 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, onFav }) {
           {!card.illustration && card.image && (
             <img src={card.image} alt="illustration" className="mb-2" />
           )}
+          {card.type === 'video' && card.video && (
+            <video src={card.video} controls className="mb-2" />
+          )}
           <p>{card.description}</p>
           {card.summary && <p className="text-sm text-gray-600">{card.summary}</p>}
+          {card.createdAt && (
+            <p className="text-xs text-gray-500 mt-1">
+              {new Date(card.createdAt).toLocaleDateString()}
+            </p>
+          )}
           <div className="mt-2 space-x-1">
             {card.tags.map(tag => (
               <span
                 key={tag}
-                className={`inline-block px-2 py-1 text-xs rounded ${tagColors[tag.toLowerCase()] || 'bg-gray-200 text-gray-700'}`}
+                className="inline-block px-2 py-1 text-xs rounded text-gray-700"
+                style={{ backgroundColor: tagColor(tag) }}
               >
                 {tag}
               </span>

--- a/frontend/src/components/GraphView.jsx
+++ b/frontend/src/components/GraphView.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { tagColor } from '../tagColors';
 
 export default function GraphView({ cards, links, onLink, onLinkEdit }) {
   const [deckFilter, setDeckFilter] = useState('');
@@ -25,6 +26,12 @@ export default function GraphView({ cards, links, onLink, onLinkEdit }) {
         data: {
           label: `${c.title}${c.decks?.length > 1 ? ' 🔁' : ''}`,
         },
+        style: {
+          border: `2px solid ${c.tags[0] ? tagColor(c.tags[0]) : '#d1d5db'}`,
+          padding: 10,
+          borderRadius: 8,
+          background: '#fff'
+        }
       })),
     [filtered]
   );
@@ -37,15 +44,17 @@ export default function GraphView({ cards, links, onLink, onLinkEdit }) {
             filtered.some(c => c.id === l.from) &&
             filtered.some(c => c.id === l.to)
         )
-        .map(l => ({ id: l.id, source: l.from, target: l.to, label: l.type, data: { type: l.type } })),
+        .map(l => ({ id: l.id, source: l.from, target: l.to, label: l.annotation || l.type, data: { type: l.type, annotation: l.annotation } })),
     [links, filtered, linkFilter]
   );
 
   const handleConnect = useCallback(
     params => {
       const type = prompt('Link type (e.g., inspires, completes)', 'related');
-      if (type && onLink) {
-        onLink(params.source, params.target, type);
+      if (!type) return;
+      const annotation = prompt('Annotation');
+      if (onLink) {
+        onLink(params.source, params.target, type, annotation);
       }
     },
     [onLink]
@@ -54,8 +63,10 @@ export default function GraphView({ cards, links, onLink, onLinkEdit }) {
   const handleEdgeClick = useCallback(
     (_, edge) => {
       const type = prompt('Edit link type', edge.data?.type || edge.label || '');
-      if (type !== null && onLinkEdit) {
-        onLinkEdit(edge.id, type);
+      if (type === null) return;
+      const annotation = prompt('Edit annotation', edge.data?.annotation || '');
+      if (annotation !== null && onLinkEdit) {
+        onLinkEdit(edge.id, type, annotation);
       }
     },
     [onLinkEdit]

--- a/frontend/src/tagColors.js
+++ b/frontend/src/tagColors.js
@@ -1,0 +1,5 @@
+export const tagColor = tag => {
+  const hash = Array.from(tag).reduce((h, c) => h + c.charCodeAt(0), 0);
+  const hue = hash % 360;
+  return `hsl(${hue},70%,80%)`;
+};

--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,9 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
 let cards = JSON.parse(localStorage.getItem('cards') || '[]');
 if (cards.length === 0) {
   cards = [

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MemoryApp Demo</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="manifest" href="manifest.json" />
 </head>
 <body>
   <header>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "MemoryApp Demo",
+  "short_name": "MemoryApp",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Offline demo for MemoryApp",
+  "icons": []
+}
+

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('memoryapp-demo-v1').then(cache =>
+      cache.addAll(['/','/index.html','/style.css','/app.js','/suggestions.js','/manifest.json'])
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});
+

--- a/src/card.js
+++ b/src/card.js
@@ -72,6 +72,22 @@ class Card {
       .map(s => s.toLowerCase());
     this.searchText = parts.join(' ');
   }
+
+  toJSON() {
+    return {
+      id: this.id,
+      title: this.title,
+      content: this.content,
+      source: this.source,
+      tags: Array.from(this.tags),
+      decks: Array.from(this.decks),
+      type: this.type,
+      description: this.description,
+      createdAt: this.createdAt,
+      summary: this.summary,
+      illustration: this.illustration,
+    };
+  }
 }
 
 module.exports = Card;

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,8 @@ const http = require('http');
 const fs = require('fs');
 const MemoryApp = require('./app');
 
-const app = new MemoryApp();
+const ENC_KEY = process.env.ENCRYPTION_KEY || '';
+let app = new MemoryApp({ dbPath: process.env.DB_PATH, encryptionKey: ENC_KEY });
 
 function json(req, callback) {
   let body = '';
@@ -18,6 +19,7 @@ function json(req, callback) {
 }
 
 const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
   if (req.method === 'POST' && req.url === '/api/cards') {
     json(req, async (err, data) => {
       if (err) {
@@ -51,6 +53,147 @@ const server = http.createServer((req, res) => {
         res.end(e.message);
       }
     });
+  } else if (req.method === 'POST' && req.url === '/api/video-note') {
+    json(req, async (err, data) => {
+      if (err || !data.video) {
+        res.writeHead(400);
+        return res.end('Invalid payload');
+      }
+      try {
+        const file = `video-${Date.now()}.webm`;
+        fs.writeFileSync(file, Buffer.from(data.video, 'base64'));
+        const card = await app.createVideoNote(file, { title: data.title || 'Video note' });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(card));
+        fs.unlink(file, () => {});
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/clip') {
+    json(req, async (err, data) => {
+      if (err || !data.url) {
+        res.writeHead(400);
+        return res.end('Invalid payload');
+      }
+      try {
+        const card = await app.createCard({
+          title: data.title || data.url,
+          source: data.url,
+          content: data.content || '',
+          type: 'link'
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(card));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/illustrate') {
+    json(req, async (err, data) => {
+      if (err || !data.prompt) {
+        res.writeHead(400);
+        return res.end('Invalid payload');
+      }
+      try {
+        const image = await app.generateIllustration(data.prompt);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ image }));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/search/semantic') {
+    json(req, async (err, data) => {
+      if (err || !data.query) {
+        res.writeHead(400);
+        return res.end('Invalid payload');
+      }
+      try {
+        const results = await app.searchBySemantic(data.query, data.limit);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(results));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/chat') {
+    json(req, async (err, data) => {
+      if (err || !data.query) {
+        res.writeHead(400);
+        return res.end('Invalid payload');
+      }
+      try {
+        const reply = await app.chat(data.query);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ reply }));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.method === 'GET' && req.url === '/api/cards') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(app.toJSON()));
+  } else if (req.method === 'GET' && req.url === '/api/export') {
+    app.exportZipBuffer().then(buffer => {
+      res.writeHead(200, { 'Content-Type': 'application/zip' });
+      res.end(buffer);
+    }).catch(e => {
+      res.writeHead(500);
+      res.end(e.message);
+    });
+  } else if (req.method === 'POST' && req.url === '/api/import') {
+    const chunks = [];
+    req.on('data', c => chunks.push(c));
+    req.on('end', async () => {
+      try {
+        const buffer = Buffer.concat(chunks);
+        app = await MemoryApp.importZipBuffer(buffer);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(e.message);
+      }
+    });
+  } else if (req.url === '/api/settings') {
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          aiEnabled: app.aiEnabled,
+          webSuggestionsEnabled: app.webSuggestionsEnabled,
+        })
+      );
+    } else if (req.method === 'POST') {
+      json(req, (err, data) => {
+        if (err) {
+          res.writeHead(400);
+          return res.end('Invalid JSON');
+        }
+        if (typeof data.aiEnabled === 'boolean') {
+          app.setAIEnabled(data.aiEnabled);
+        }
+        if (typeof data.webSuggestionsEnabled === 'boolean') {
+          app.setWebSuggestionsEnabled(data.webSuggestionsEnabled);
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            aiEnabled: app.aiEnabled,
+            webSuggestionsEnabled: app.webSuggestionsEnabled,
+          })
+        );
+      });
+    } else {
+      res.writeHead(405);
+      res.end('Method not allowed');
+    }
   } else {
     res.writeHead(404);
     res.end('Not found');

--- a/web-clipper/popup.js
+++ b/web-clipper/popup.js
@@ -4,10 +4,10 @@ async function clip() {
     target: { tabId: tab.id },
     func: () => window.getSelection().toString(),
   });
-  await fetch('http://localhost:3000/api/cards', {
+  await fetch('http://localhost:3000/api/clip', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title: tab.title, source: tab.url, content: selection })
+    body: JSON.stringify({ title: tab.title, url: tab.url, content: selection })
   });
   window.close();
 }


### PR DESCRIPTION
## Summary
- filter cards by tag and centralize tag color helper
- encrypt stored media files and expose helper to decrypt
- route video note uploads through API for transcription while keeping local previews
- persist link annotations by serializing them in exported data
- store card links in encrypted local storage and prune them when related cards are removed
- add export/import buttons to download or restore cards and links as JSON
- enable semantic search via dedicated endpoint and UI toggle
- generate AI illustrations through a new `/api/illustrate` endpoint and preview them in Quick Add
- provide API and UI switches to disable AI enrichment and web suggestions for offline use
- automatically build a favorites deck by tracking card usage and persisting encrypted stats
- offer a chatbot API and frontend widget so natural language queries return card-based answers
- package demo with PWA manifest and service worker to cache core assets for offline use
- expose `/api/cards`, `/api/export`, and `/api/import` endpoints so archives can be downloaded or restored through the UI
- edit cards inline to update descriptions, tags, and decks
- color graph nodes by tag-derived hues to mirror card styling
- show card creation dates on tiles and assign timestamps to newly added cards
- remove binary icon asset and rely on manifest without icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896480751108322b15fc550eaee73b4