### PR TITLE
feat: support audio note metadata

### DIFF
--- a/frontend/src/components/CardGrid.jsx
+++ b/frontend/src/components/CardGrid.jsx
@@ -41,7 +41,15 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, tagPalette
             <video src={card.video} controls className="mb-2" />
           )}
           {card.type === 'audio' && card.audio && (
-            <audio src={card.audio} controls className="mb-2 w-full" />
+            <div className="mb-2">
+              <audio src={card.audio} controls className="w-full" />
+              {card.contentType && (
+                <p className="text-sm text-gray-600">Format: {card.contentType}</p>
+              )}
+              {typeof card.duration === 'number' && card.duration > 0 && (
+                <p className="text-sm text-gray-600">Duration: {card.duration.toFixed(1)}s</p>
+              )}
+            </div>
           )}
           <p>{card.description}</p>
           {card.summary && <p className="text-sm text-gray-600">{card.summary}</p>}

--- a/src/card.js
+++ b/src/card.js
@@ -11,6 +11,8 @@ class Card {
     createdAt = new Date().toISOString(),
     summary = '',
     illustration = '',
+    contentType = '',
+    duration = 0,
   }) {
     this.id = id;
     this.title = title;
@@ -23,6 +25,8 @@ class Card {
     this.createdAt = createdAt;
     this.summary = summary;
     this.illustration = illustration;
+    this.contentType = contentType;
+    this.duration = duration;
     this._updateSearchText();
   }
 
@@ -38,7 +42,7 @@ class Card {
     this.tags.delete(tag);
   }
 
-  update({ title, content, source, tags, description, type, summary, illustration }) {
+  update({ title, content, source, tags, description, type, summary, illustration, contentType, duration }) {
     if (title !== undefined) {
       this.title = title;
     }
@@ -63,6 +67,12 @@ class Card {
     if (illustration !== undefined) {
       this.illustration = illustration;
     }
+    if (contentType !== undefined) {
+      this.contentType = contentType;
+    }
+    if (duration !== undefined) {
+      this.duration = duration;
+    }
     this._updateSearchText();
   }
 
@@ -86,6 +96,8 @@ class Card {
       createdAt: this.createdAt,
       summary: this.summary,
       illustration: this.illustration,
+      contentType: this.contentType,
+      duration: this.duration,
     };
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -44,7 +44,11 @@ const server = http.createServer((req, res) => {
       try {
         const file = `audio-${Date.now()}.webm`;
         fs.writeFileSync(file, Buffer.from(data.audio, 'base64'));
-        const card = await app.createAudioNote(file, { title: data.title || 'Audio note' });
+        const card = await app.createAudioNote(file, {
+          title: data.title || 'Audio note',
+          contentType: data.contentType,
+          duration: data.duration,
+        });
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(card));
         fs.unlink(file, () => {});

--- a/test.js
+++ b/test.js
@@ -342,9 +342,15 @@ const { SimpleAI } = require('./src/ai');
   transAI.transcribe = async () => 'spoken words';
   const audioApp = new MemoryApp({ ai: transAI });
   fs.writeFileSync('note.webm', 'dummy');
-  const audioCard = await audioApp.createAudioNote('note.webm', { title: 'Voice' });
+  const audioCard = await audioApp.createAudioNote('note.webm', {
+    title: 'Voice',
+    contentType: 'audio/webm',
+    duration: 0,
+  });
   assert.strictEqual(audioCard.content, 'spoken words', 'Audio note should transcribe content');
   assert.strictEqual(audioCard.type, 'audio', 'Audio note should have audio type');
+  assert.strictEqual(audioCard.contentType, 'audio/webm', 'Audio note should record content type');
+  assert.strictEqual(audioCard.duration, 0, 'Audio note should record duration');
 
   // Favorite deck from usage stats
   const usageApp = new MemoryApp();


### PR DESCRIPTION
## Summary
- detect audio files in QuickAdd, capture mime type and duration, and preview recordings
- post audio blobs with metadata to /api/audio-note and persist content type and duration
- render audio card playback with format and length information

## Testing
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897034c379483228e2bcaca83c01ccd