### PR TITLE
feat: add IndexedDB layer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "crypto-js": "^4.2.0",
         "fuse.js": "^7.1.0",
+        "idb": "^8.0.3",
         "idb-keyval": "^6.2.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2992,6 +2993,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/idb-keyval": {
       "version": "6.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "crypto-js": "^4.2.0",
     "fuse.js": "^7.1.0",
+    "idb": "^8.0.3",
     "idb-keyval": "^6.2.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,21 @@ import Chatbot from './components/Chatbot';
 import ThemeSettings from './components/ThemeSettings';
 import CryptoJS from 'crypto-js';
 import { get, set } from 'idb-keyval';
+import { openDB } from 'idb';
+
+const dbPromise = openDB('memory-store', 1, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains('cards')) {
+      db.createObjectStore('cards', { keyPath: 'id' });
+    }
+    if (!db.objectStoreNames.contains('links')) {
+      db.createObjectStore('links', { keyPath: 'id' });
+    }
+    if (!db.objectStoreNames.contains('usage')) {
+      db.createObjectStore('usage');
+    }
+  },
+});
 
 const defaultCards = [
   {
@@ -62,56 +77,110 @@ export default function App() {
   const [theme, setTheme] = useState('light');
   const [tagPalette, setTagPalette] = useState({});
   const importRef = useRef();
-
   const loadCards = async () => {
-    let raw = await get('cards');
-    if (!raw) return [];
-    try {
-      raw = decrypt(raw, encKey);
-      return JSON.parse(raw);
-    } catch {
-      return [];
-    }
+    const db = await dbPromise;
+    const store = db.transaction('cards').objectStore('cards');
+    const all = await store.getAll();
+    return all
+      .map(({ data }) => {
+        try {
+          return JSON.parse(decrypt(data, encKey));
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
   };
 
   const saveCards = async list => {
-    let raw = JSON.stringify(list);
-    raw = encrypt(raw, encKey);
-    await set('cards', raw);
+    const db = await dbPromise;
+    const tx = db.transaction('cards', 'readwrite');
+    const store = tx.objectStore('cards');
+    await store.clear();
+    for (const card of list) {
+      const data = encrypt(JSON.stringify(card), encKey);
+      await store.put({ id: card.id, data });
+    }
   };
 
   const loadLinks = async () => {
-    let raw = await get('links');
-    if (!raw) return [];
-    try {
-      raw = decrypt(raw, encKey);
-      return JSON.parse(raw);
-    } catch {
-      return [];
-    }
+    const db = await dbPromise;
+    const store = db.transaction('links').objectStore('links');
+    const all = await store.getAll();
+    return all
+      .map(({ data }) => {
+        try {
+          return JSON.parse(decrypt(data, encKey));
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
   };
 
   const saveLinks = async list => {
-    let raw = JSON.stringify(list);
-    raw = encrypt(raw, encKey);
-    await set('links', raw);
-  };
-
-  const loadUsage = async () => {
-    let raw = await get('usage');
-    if (!raw) return {};
-    try {
-      raw = decrypt(raw, encKey);
-      return JSON.parse(raw);
-    } catch {
-      return {};
+    const db = await dbPromise;
+    const tx = db.transaction('links', 'readwrite');
+    const store = tx.objectStore('links');
+    await store.clear();
+    for (const link of list) {
+      const data = encrypt(JSON.stringify(link), encKey);
+      await store.put({ id: link.id, data });
     }
   };
 
+  const loadUsage = async () => {
+    const db = await dbPromise;
+    const store = db.transaction('usage').objectStore('usage');
+    const keys = await store.getAllKeys();
+    const result = {};
+    for (const key of keys) {
+      const val = await store.get(key);
+      try {
+        result[key] = JSON.parse(decrypt(val, encKey));
+      } catch {
+        result[key] = 0;
+      }
+    }
+    return result;
+  };
+
   const saveUsage = async map => {
-    let raw = JSON.stringify(map);
-    raw = encrypt(raw, encKey);
-    await set('usage', raw);
+    const db = await dbPromise;
+    const tx = db.transaction('usage', 'readwrite');
+    const store = tx.objectStore('usage');
+    await store.clear();
+    for (const [key, val] of Object.entries(map)) {
+      const data = encrypt(JSON.stringify(val), encKey);
+      await store.put(data, key);
+    }
+  };
+
+  const migrateLocalStorage = async () => {
+    const db = await dbPromise;
+    const count = await db.count('cards');
+    if (count > 0) return;
+    const legacyCards = localStorage.getItem('cards');
+    const legacyLinks = localStorage.getItem('links');
+    const legacyUsage = localStorage.getItem('usage');
+    if (legacyCards) {
+      try {
+        await saveCards(JSON.parse(legacyCards));
+      } catch { /* ignore */ }
+      localStorage.removeItem('cards');
+    }
+    if (legacyLinks) {
+      try {
+        await saveLinks(JSON.parse(legacyLinks));
+      } catch { /* ignore */ }
+      localStorage.removeItem('links');
+    }
+    if (legacyUsage) {
+      try {
+        await saveUsage(JSON.parse(legacyUsage));
+      } catch { /* ignore */ }
+      localStorage.removeItem('usage');
+    }
   };
 
   useEffect(() => {
@@ -124,6 +193,7 @@ export default function App() {
 
   useEffect(() => {
     async function init() {
+      await migrateLocalStorage();
       try {
         const res = await fetch('/api/cards');
         if (res.ok) {
@@ -325,6 +395,7 @@ export default function App() {
       set('encryptionKey', k);
       saveCards(cards);
       saveLinks(links);
+      saveUsage(usage);
     }
   };
 


### PR DESCRIPTION
## Summary
- add IndexedDB schema for cards, links, and usage stats
- migrate existing localStorage data into IndexedDB on first run
- update encryption key handling to persist usage stats

## Testing
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689704b520c8832290b331925e68ab84