### PR TITLE
feat: customizable card colors and tag palette

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import Chatbot from './components/Chatbot';
 import ThemeSettings from './components/ThemeSettings';
 import CryptoJS from 'crypto-js';
 import { get, set } from 'idb-keyval';
+import { setTagPaletteCache } from './tagColors';
 
 const defaultCards = [
   {
@@ -61,6 +62,8 @@ export default function App() {
   const [usage, setUsage] = useState({});
   const [theme, setTheme] = useState('light');
   const [tagPalette, setTagPalette] = useState({});
+  const [cardBg, setCardBg] = useState('#ffffff');
+  const [cardBorder, setCardBorder] = useState('#d1d5db');
   const importRef = useRef();
 
   const loadCards = async () => {
@@ -119,7 +122,14 @@ export default function App() {
     get('aiEnabled').then(v => setAiEnabled(v === undefined ? true : v));
     get('webSuggestionsEnabled').then(v => setWebSuggestionsEnabled(v === undefined ? true : v));
     get('theme').then(t => t && setTheme(t));
-    get('tagPalette').then(p => p && setTagPalette(p));
+    get('tagPalette').then(p => {
+      if (p) {
+        setTagPalette(p);
+        setTagPaletteCache(p);
+      }
+    });
+    get('cardBg').then(c => c && setCardBg(c));
+    get('cardBorder').then(c => c && setCardBorder(c));
   }, []);
 
   useEffect(() => {
@@ -436,6 +446,17 @@ export default function App() {
           setTagPalette={p => {
             setTagPalette(p);
             set('tagPalette', p);
+            setTagPaletteCache(p);
+          }}
+          cardBg={cardBg}
+          setCardBg={c => {
+            setCardBg(c);
+            set('cardBg', c);
+          }}
+          cardBorder={cardBorder}
+          setCardBorder={c => {
+            setCardBorder(c);
+            set('cardBorder', c);
           }}
         />
         <QuickAdd onAdd={addCard} initial={quickAddInitial} aiEnabled={aiEnabled} />
@@ -445,7 +466,8 @@ export default function App() {
             links={links}
             onLink={handleLinkCreate}
             onLinkEdit={handleLinkEdit}
-            tagPalette={tagPalette}
+            cardBg={cardBg}
+            cardBorder={cardBorder}
           />
         ) : (
           <CardGrid
@@ -453,7 +475,8 @@ export default function App() {
             onSelect={selectCard}
             onEdit={editCard}
             onDelete={deleteCard}
-            tagPalette={tagPalette}
+            cardBg={cardBg}
+            cardBorder={cardBorder}
           />
         )}
         <div className="mt-6">

--- a/frontend/src/components/CardGrid.jsx
+++ b/frontend/src/components/CardGrid.jsx
@@ -10,17 +10,20 @@ const typeIcons = {
   audio: '🎤',
 };
 
-export default function CardGrid({ cards, onSelect, onEdit, onDelete, tagPalette }) {
+export default function CardGrid({ cards, onSelect, onEdit, onDelete, cardBg, cardBorder }) {
   if (!cards.length) {
-    return <p className="text-gray-500">No cards found</p>;
+    return <p className="text-gray-500 dark:text-gray-400">No cards found</p>;
   }
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
       {cards.map(card => (
         <div
           key={card.id}
-          className="group relative bg-white border-4 p-4 rounded-xl cursor-pointer shadow-md hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition"
-          style={{ borderColor: card.tags[0] ? tagColor(card.tags[0], tagPalette) : '#d1d5db' }}
+          className="group relative border-4 p-4 rounded-xl cursor-pointer shadow-md hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition bg-white dark:bg-gray-800 dark:text-white"
+          style={{
+            backgroundColor: cardBg,
+            borderColor: card.tags[0] ? tagColor(card.tags[0]) : cardBorder,
+          }}
           onClick={() => onSelect(card)}
         >
           <div className="absolute top-1 right-1 space-x-1 opacity-0 group-hover:opacity-100">
@@ -44,17 +47,19 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, tagPalette
             <div className="mb-2">
               <audio src={card.audio} controls className="w-full" />
               {card.contentType && (
-                <p className="text-sm text-gray-600">Format: {card.contentType}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">Format: {card.contentType}</p>
               )}
               {typeof card.duration === 'number' && card.duration > 0 && (
-                <p className="text-sm text-gray-600">Duration: {card.duration.toFixed(1)}s</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">Duration: {card.duration.toFixed(1)}s</p>
               )}
             </div>
           )}
           <p>{card.description}</p>
-          {card.summary && <p className="text-sm text-gray-600">{card.summary}</p>}
+          {card.summary && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">{card.summary}</p>
+          )}
           {card.createdAt && (
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
               {new Date(card.createdAt).toLocaleDateString()}
             </p>
           )}
@@ -62,8 +67,8 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, tagPalette
             {card.tags.map(tag => (
               <span
                 key={tag}
-                className="inline-block px-2 py-1 text-xs rounded text-gray-700"
-                style={{ backgroundColor: tagColor(tag, tagPalette) }}
+                className="inline-block px-2 py-1 text-xs rounded text-gray-700 dark:text-gray-200"
+                style={{ backgroundColor: tagColor(tag) }}
               >
                 {tag}
               </span>
@@ -74,7 +79,7 @@ export default function CardGrid({ cards, onSelect, onEdit, onDelete, tagPalette
               {card.decks.map(deck => (
                 <span
                   key={deck}
-                  className="inline-block bg-blue-100 text-blue-700 px-2 py-1 text-xs rounded"
+                  className="inline-block bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 px-2 py-1 text-xs rounded"
                 >
                   {deck}
                 </span>

--- a/frontend/src/components/DeckSidebar.jsx
+++ b/frontend/src/components/DeckSidebar.jsx
@@ -2,15 +2,23 @@ import React from 'react';
 
 export default function DeckSidebar({ decks, current, onSelect }) {
   return (
-    <aside className="w-40 border-r pr-2">
+    <aside className="w-40 border-r pr-2 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-100">
       <h2 className="font-semibold mb-2">Decks</h2>
       <ul className="space-y-1">
         <li className={current === null ? 'font-bold' : ''}>
-          <button onClick={() => onSelect(null)}>All</button>
+          <button
+            onClick={() => onSelect(null)}
+            className="w-full text-left rounded px-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+          >
+            All
+          </button>
         </li>
         {Object.entries(decks).map(([d, count]) => (
           <li key={d} className={current === d ? 'font-bold' : ''}>
-            <button onClick={() => onSelect(d)}>
+            <button
+              onClick={() => onSelect(d)}
+              className="w-full text-left rounded px-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+            >
               {d} ({count})
             </button>
           </li>

--- a/frontend/src/components/GraphView.jsx
+++ b/frontend/src/components/GraphView.jsx
@@ -3,7 +3,7 @@ import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { tagColor } from '../tagColors';
 
-export default function GraphView({ cards, links, onLink, onLinkEdit, tagPalette }) {
+export default function GraphView({ cards, links, onLink, onLinkEdit, cardBg, cardBorder }) {
   const [deckFilter, setDeckFilter] = useState('');
   const [tagFilter, setTagFilter] = useState('');
   const [linkFilter, setLinkFilter] = useState('');
@@ -27,13 +27,13 @@ export default function GraphView({ cards, links, onLink, onLinkEdit, tagPalette
           label: `${c.title}${c.decks?.length > 1 ? ' 🔁' : ''}`,
         },
         style: {
-          border: `2px solid ${c.tags[0] ? tagColor(c.tags[0], tagPalette) : '#d1d5db'}`,
+          border: `2px solid ${c.tags[0] ? tagColor(c.tags[0]) : cardBorder}`,
           padding: 10,
           borderRadius: 8,
-          background: '#fff'
+          background: cardBg
         }
       })),
-    [filtered, tagPalette]
+    [filtered, cardBg, cardBorder]
   );
   const edges = useMemo(
     () =>
@@ -82,7 +82,7 @@ export default function GraphView({ cards, links, onLink, onLinkEdit, tagPalette
         <select
           value={deckFilter}
           onChange={e => setDeckFilter(e.target.value)}
-          className="border px-2"
+          className="border px-2 bg-white dark:bg-gray-800"
         >
           <option value="">All Decks</option>
           {deckOptions.map(d => (
@@ -94,7 +94,7 @@ export default function GraphView({ cards, links, onLink, onLinkEdit, tagPalette
         <select
           value={tagFilter}
           onChange={e => setTagFilter(e.target.value)}
-          className="border px-2"
+          className="border px-2 bg-white dark:bg-gray-800"
         >
           <option value="">All Tags</option>
           {tagOptions.map(t => (
@@ -106,7 +106,7 @@ export default function GraphView({ cards, links, onLink, onLinkEdit, tagPalette
         <select
           value={linkFilter}
           onChange={e => setLinkFilter(e.target.value)}
-          className="border px-2"
+          className="border px-2 bg-white dark:bg-gray-800"
         >
           <option value="">All Link Types</option>
           {linkTypeOptions.map(t => (

--- a/frontend/src/components/ThemeSettings.jsx
+++ b/frontend/src/components/ThemeSettings.jsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 
-export default function ThemeSettings({ theme, setTheme, tagPalette, setTagPalette }) {
+export default function ThemeSettings({
+  theme,
+  setTheme,
+  tagPalette,
+  setTagPalette,
+  cardBg,
+  setCardBg,
+  cardBorder,
+  setCardBorder,
+}) {
   const [tag, setTag] = useState('');
   const [color, setColor] = useState('#ff0000');
 
@@ -23,6 +32,12 @@ export default function ThemeSettings({ theme, setTheme, tagPalette, setTagPalet
           <option value="light">Light</option>
           <option value="dark">Dark</option>
         </select>
+      </div>
+      <div className="flex items-center space-x-2 mb-2">
+        <label>Card bg:</label>
+        <input type="color" value={cardBg} onChange={e => setCardBg(e.target.value)} />
+        <label>Border:</label>
+        <input type="color" value={cardBorder} onChange={e => setCardBorder(e.target.value)} />
       </div>
       <div className="flex items-center space-x-2 mb-2">
         <input

--- a/frontend/src/tagColors.js
+++ b/frontend/src/tagColors.js
@@ -1,7 +1,21 @@
+import { get } from 'idb-keyval';
+
+let storedPalette = {};
+get('tagPalette').then(p => {
+  if (p) storedPalette = p;
+});
+
+export const setTagPaletteCache = p => {
+  storedPalette = p || {};
+};
+
 const defaultColor = tag => {
   const hash = Array.from(tag).reduce((h, c) => h + c.charCodeAt(0), 0);
   const hue = hash % 360;
   return `hsl(${hue},70%,80%)`;
 };
 
-export const tagColor = (tag, palette = {}) => palette[tag] || defaultColor(tag);
+export const tagColor = (tag, palette) => {
+  const pal = palette || storedPalette;
+  return pal[tag] || defaultColor(tag);
+};


### PR DESCRIPTION
## Summary
- allow users to configure card background/border colors and tag palettes
- persist theme settings in IndexedDB and sync tagColors helper
- apply theme-aware styling across card grid, deck sidebar, and graph view

## Testing
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689704caf6688322aa85f012a62df3f2