### PR TITLE
Improve suggestion cache, AI timeouts, SSE resilience, and media streaming

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,8 +11,10 @@ Write app events to the given log file.
 ### `saveEncryptedToFile(path, password)` / `loadEncryptedFromFile(path, password)`
 Persist card data encrypted with a password.
 
-### `saveMedia(buffer, filename)`
-Store a media file under the `storage/` directory.
+### `saveMedia(input, filename)`
+Store a media file under the `storage/` directory. `input` may be a `Buffer`
+or a path to an existing file; when a path is provided the file is moved into
+storage without being fully read into memory.
 
 ### `exportZip(path)` / `importZip(path)`
 Export or import cards and stored media as a ZIP archive.

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,29 @@ import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
 import crypto from 'crypto';
 
+export interface CardRecord {
+  id: string;
+  title?: string;
+  content?: string;
+  source?: string;
+  tags: Iterable<string>;
+  decks: Iterable<string>;
+  type: string;
+  description?: string;
+  createdAt: string;
+  summary?: string;
+  illustration?: string;
+  embedding?: number[] | null;
+}
+
+export interface LinkRecord {
+  id: string;
+  from: string;
+  to: string;
+  type: string;
+  annotation?: string;
+}
+
 class MemoryDB {
   path: string;
   key?: string;
@@ -40,7 +63,7 @@ class MemoryDB {
     await this.db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS card_search USING fts5(id, title, content, description)`);
   }
 
-  async saveCard(card: any): Promise<void> {
+  async saveCard(card: CardRecord): Promise<void> {
     await this.ready;
     await this.db.run(
       `INSERT OR REPLACE INTO cards (
@@ -81,7 +104,7 @@ class MemoryDB {
     await this.db.run('DELETE FROM card_search WHERE id = ?', id);
   }
 
-  async loadCards(): Promise<any[]> {
+  async loadCards(): Promise<CardRecord[]> {
     await this.ready;
     const rows = await this.db.all<any[]>('SELECT * FROM cards');
     return rows.map(r => ({
@@ -100,7 +123,7 @@ class MemoryDB {
     }));
   }
 
-  async saveLink(link: any): Promise<void> {
+  async saveLink(link: LinkRecord): Promise<void> {
     await this.ready;
     await this.db.run(
       'INSERT OR REPLACE INTO links (id, fromId, toId, type, annotation) VALUES (?, ?, ?, ?, ?)',
@@ -113,7 +136,7 @@ class MemoryDB {
     await this.db.run('DELETE FROM links WHERE id = ?', id);
   }
 
-  async loadLinks(): Promise<any[]> {
+  async loadLinks(): Promise<LinkRecord[]> {
     await this.ready;
     const rows = await this.db.all<any[]>('SELECT * FROM links');
     return rows.map(r => ({

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -20,11 +20,13 @@ async function fetchWithCache(tag: string, source: string, fn: (tag: string) => 
     return cached.value;
   }
   if (cached) {
-    fn(tag).then(res => {
-      if (res) {
-        cache.set(key, { ts: Date.now(), value: res });
-      }
-    });
+    fn(tag)
+      .then(res => {
+        if (res) {
+          cache.set(key, { ts: Date.now(), value: res });
+        }
+      })
+      .catch(() => {});
     return cached.value;
   }
   const res = await fn(tag);
@@ -187,6 +189,7 @@ export async function fetchSuggestion(tag: string, type = 'text') {
 }
 
 export {
+  fetchWithCache,
   fetchFromWikipedia,
   fetchFromReddit,
   fetchFromRSS,


### PR DESCRIPTION
## Summary
- swallow errors when refreshing cached suggestions
- add configurable timeouts for HuggingFace AI requests
- make SSE broadcast drop closed connections and send heartbeats
- stream uploaded media to storage and accept file paths in saveMedia
- define strict CardRecord and LinkRecord types for the database

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ba1c87008322be331cb10e2d55d8