### PR TITLE
Add missing APIs and improve encryption and suggestions

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -91,9 +91,10 @@ class MemoryDB {
       [
         card.id,
         card.id,
-        this.encrypt(card.title),
-        this.encrypt(card.content),
-        this.encrypt(card.description)
+        // Store plaintext in FTS table so search works with encryption
+        card.title,
+        card.content,
+        card.description
       ]
     );
   }
@@ -150,21 +151,26 @@ class MemoryDB {
 
   encrypt(text: any) {
     if (!this.key || text === undefined || text === null) return text;
-    const iv = crypto.randomBytes(16);
+    const iv = crypto.randomBytes(12);
     const key = crypto.createHash('sha256').update(this.key).digest();
-    const cipher = crypto.createCipheriv('aes-256-ctr', key, iv);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
     const encrypted = Buffer.concat([cipher.update(String(text), 'utf8'), cipher.final()]);
-    return iv.toString('hex') + ':' + encrypted.toString('hex');
+    const tag = cipher.getAuthTag();
+    return (
+      iv.toString('hex') + ':' + tag.toString('hex') + ':' + encrypted.toString('hex')
+    );
   }
 
   decrypt(text: any) {
     if (!this.key || text === undefined || text === null) return text;
     try {
-      const [ivHex, dataHex] = String(text).split(':');
+      const [ivHex, tagHex, dataHex] = String(text).split(':');
       const iv = Buffer.from(ivHex, 'hex');
+      const tag = Buffer.from(tagHex, 'hex');
       const encrypted = Buffer.from(dataHex, 'hex');
       const key = crypto.createHash('sha256').update(this.key).digest();
-      const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(tag);
       return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
     } catch {
       return '';


### PR DESCRIPTION
## Summary
- add illustration generation and usage tracking API endpoints
- migrate to AES-256-GCM and index plaintext for FTS search
- parallelize web suggestion fetching with cancellation and await DB saves
- expand server API with card retrieval, semantic search, link management, settings, and chat endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c2809af88322a91913818688baf7