### PR TITLE
Add loading feedback, accessible modals, search enhancements, and theme contrast validation

### DIFF
--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -2,12 +2,16 @@ import React, { useState } from 'react';
 
 export default function Chatbot() {
   const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleSend = async e => {
     e.preventDefault();
     const text = e.target.elements.msg.value.trim();
     if (!text) return;
     setMessages(prev => [...prev, { from: 'user', text }]);
+    setLoading(true);
+    setError(null);
     try {
       const res = await fetch('/api/chat', {
         method: 'POST',
@@ -18,6 +22,9 @@ export default function Chatbot() {
       setMessages(prev => [...prev, { from: 'bot', text: data.reply || 'No response' }]);
     } catch {
       setMessages(prev => [...prev, { from: 'bot', text: 'Error contacting server.' }]);
+      setError('Error contacting server.');
+    } finally {
+      setLoading(false);
     }
     e.target.reset();
   };
@@ -32,9 +39,15 @@ export default function Chatbot() {
             </span>
           </div>
         ))}
+        {loading && (
+          <div className="text-left">
+            <span className="inline-block bg-gray-200 p-1 rounded">Typing...</span>
+          </div>
+        )}
       </div>
+      {error && <div className="text-red-600 mb-2">{error}</div>}
       <form onSubmit={handleSend} className="flex space-x-1">
-        <input name="msg" className="border flex-1 p-1" placeholder="Ask the bot..." />
+        <input name="msg" className="border flex-1 p-1" placeholder="Ask the bot..." aria-label="Chat message" />
         <button className="border px-2">Send</button>
       </form>
     </div>

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+
+export default function Modal({ title, children, onClose }) {
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-sm w-full">
+        <div className="flex justify-between items-center mb-2">
+          <h2 id="modal-title" className="text-lg">
+            {title}
+          </h2>
+          <button onClick={onClose} aria-label="Close" className="text-xl">
+            &times;
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/ThemeSettings.jsx
+++ b/frontend/src/components/ThemeSettings.jsx
@@ -1,5 +1,21 @@
 import React, { useState } from 'react';
 
+function luminance(hex) {
+  const rgb = [0, 1, 2].map(i => {
+    const c = parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+}
+
+function contrastRatio(a, b) {
+  const l1 = luminance(a);
+  const l2 = luminance(b);
+  const brightest = Math.max(l1, l2);
+  const darkest = Math.min(l1, l2);
+  return (brightest + 0.05) / (darkest + 0.05);
+}
+
 export default function ThemeSettings({
   theme,
   setTheme,
@@ -19,6 +35,9 @@ export default function ThemeSettings({
   const [tag, setTag] = useState('');
   const [color, setColor] = useState('#ff0000');
 
+  const contrast = contrastRatio(cardBg, textColor);
+  const contrastPass = contrast >= 4.5;
+
   const addTagColor = () => {
     if (tag) {
       setTagPalette({ ...tagPalette, [tag]: color });
@@ -29,8 +48,9 @@ export default function ThemeSettings({
   return (
     <div className="border p-2 mb-4">
       <div className="flex items-center space-x-2 mb-2">
-        <label>Theme:</label>
+        <label htmlFor="theme-select">Theme:</label>
         <select
+          id="theme-select"
           value={theme}
           onChange={e => setTheme(e.target.value)}
           className="border px-2"
@@ -40,31 +60,45 @@ export default function ThemeSettings({
         </select>
       </div>
       <div className="flex items-center space-x-2 mb-2">
-        <label>Card bg:</label>
-        <input type="color" value={cardBg} onChange={e => setCardBg(e.target.value)} />
-        <label>Border:</label>
-        <input type="color" value={cardBorder} onChange={e => setCardBorder(e.target.value)} />
+        <label htmlFor="card-bg">Card bg:</label>
+        <input id="card-bg" type="color" value={cardBg} onChange={e => setCardBg(e.target.value)} />
+        <label htmlFor="card-border">Border:</label>
+        <input id="card-border" type="color" value={cardBorder} onChange={e => setCardBorder(e.target.value)} />
       </div>
       <div className="flex items-center space-x-2 mb-2">
-        <label>Accent:</label>
-        <input type="color" value={accent} onChange={e => setAccent(e.target.value)} />
-        <label>Text:</label>
-        <input type="color" value={textColor} onChange={e => setTextColor(e.target.value)} />
-        <label>Font:</label>
-        <select value={font} onChange={e => setFont(e.target.value)} className="border px-2">
+        <label htmlFor="accent-color">Accent:</label>
+        <input id="accent-color" type="color" value={accent} onChange={e => setAccent(e.target.value)} />
+        <label htmlFor="text-color">Text:</label>
+        <input id="text-color" type="color" value={textColor} onChange={e => setTextColor(e.target.value)} />
+        <label htmlFor="font-select">Font:</label>
+        <select id="font-select" value={font} onChange={e => setFont(e.target.value)} className="border px-2">
           <option value="sans-serif">Sans</option>
           <option value="serif">Serif</option>
           <option value="monospace">Mono</option>
         </select>
       </div>
+      <div className="mb-2">
+        <p className={`text-sm ${contrastPass ? 'text-green-600' : 'text-red-600'}`}>
+          Contrast ratio {contrast.toFixed(2)} {contrastPass ? 'passes' : 'fails'} WCAG 4.5:1
+        </p>
+        <div
+          className="mt-1 p-2 rounded border"
+          style={{ backgroundColor: cardBg, color: textColor, borderColor: cardBorder }}
+        >
+          Preview text
+        </div>
+      </div>
       <div className="flex items-center space-x-2 mb-2">
+        <label htmlFor="tag-name" className="sr-only">Tag</label>
         <input
+          id="tag-name"
           className="border p-1"
           placeholder="Tag"
           value={tag}
           onChange={e => setTag(e.target.value)}
         />
-        <input type="color" value={color} onChange={e => setColor(e.target.value)} />
+        <label htmlFor="tag-color" className="sr-only">Color</label>
+        <input id="tag-color" type="color" value={color} onChange={e => setColor(e.target.value)} />
         <button className="bg-blue-500 text-white px-2" onClick={addTagColor}>
           Add
         </button>


### PR DESCRIPTION
## Summary
- show loading and error messages when previewing or saving QuickAdd notes
- add typing indicator and error feedback in Chatbot
- label QuickAdd and Chatbot inputs for better accessibility
- label search and tag filter fields, and associate ThemeSettings controls for screen readers
- make cards focusable with keyboard activation and labelled edit/delete actions
- replace GraphView prompt dialogs with an accessible modal form for creating and editing links
- provide search suggestions and highlight matches in the card grid
- validate theme color contrast with live preview and WCAG guidance

## Testing
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d191948c83228af639d908dfaf12